### PR TITLE
Remove incorrect test expecting false to equal true

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,5 +6,4 @@ test("renders learn react link", () => {
   render(<App />);
   const linkElement = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();
-  expect(false).toBe(true);
 });


### PR DESCRIPTION
This pull request removes a test case from `src/App.test.tsx` that incorrectly expected `false` to equal `true`. The test was not meaningful and could lead to confusion. The remaining test checks for the presence of the 'learn react' link, which is a valid assertion.

---

> This pull request was co-created with Cosine Genie

Original Task: [sandbox/umprf38f6osn](http://localhost:3000/e8meg6qwinmt/sandbox/task/umprf38f6osn)
Author: Tom Dowley
