### PR TITLE
Remove incorrect test assertion

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,5 +6,4 @@ test("renders learn react link", () => {
   render(<App />);
   const linkElement = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();
-  expect(false).toBe(true);
 });


### PR DESCRIPTION
This pull request removes the test assertion that incorrectly expected `false` to be `true` in `src/App.test.tsx`. The test now only checks for the presence of the 'learn react' link, which is the intended behavior.

---

> This pull request was co-created with Cosine Genie

Original Task: [sandbox/c9r8dtv4o9x3](http://localhost:3000/e8meg6qwinmt/sandbox/task/c9r8dtv4o9x3)
Author: Tom Dowley
