### PR TITLE
Remove Invalid Test Assertion

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,5 +6,4 @@ test("renders learn react link", () => {
   render(<App />);
   const linkElement = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();
-  expect(false).toBe(true);
 });


### PR DESCRIPTION
This pull request removes an invalid test assertion from `src/App.test.tsx` that incorrectly asserts `false` equals `true`. The test now only checks for the presence of the 'learn react' link, which is the intended functionality. This change helps to clean up the test suite and ensures that tests accurately reflect the expected behavior.

---

> This pull request was co-created with Cosine Genie

Original Task: [sandbox/in44msnfg5qc](http://localhost:3000/e8meg6qwinmt/sandbox/task/in44msnfg5qc)
Author: Tom Dowley
