### PR TITLE
Remove Invalid Test Assertion

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,5 +6,4 @@ test("renders learn react link", () => {
   render(<App />);
   const linkElement = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();
-  expect(false).toBe(true);
 });


### PR DESCRIPTION
This pull request removes the invalid assertion `expect(false).toBe(true);` from the test file `src/App.test.tsx`. This assertion was causing the test to fail unnecessarily. The remaining test checks for the presence of the 'learn react' link, which is the intended functionality.

---

> This pull request was co-created with Cosine Genie

Original Task: [sandbox/vmgu4c1yuyho](http://localhost:3000/e8meg6qwinmt/sandbox/task/vmgu4c1yuyho)
Author: Tom Dowley
