### PR TITLE
Add playful roast to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,13 @@ If you aren’t satisfied with the build tool and configuration choices, you can
 Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
 
 You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+
+## Roast
+
+Congratulations on reading the README—most developers skip it and then wonder why nothing works.
+
+If debugging is your process, maybe you should consider a career in archaeology—because clearly, you love digging for things you lost.
+
+Running `npm start`? Bold move. Let's hope your code works better than your sense of humor.
+
+Remember, every time you copy-paste from Stack Overflow without understanding, a rubber duck sheds a tear.


### PR DESCRIPTION
This PR adds a humorous "Roast" section to the README.md file aimed at lightening the mood for developers who might be struggling with issues. The new section includes playful jabs about common developer pitfalls such as skipping README documentation, debugging, and the pitfalls of copy-pasting code. This addition aims to engage readers while encouraging them to read through the documentation more thoroughly.

---

> This pull request was co-created with Cosine Genie

Original Task: [sandbox/awykzi49kfio](https://cosine.wtf/w3i66bo0i5fz/sandbox/task/awykzi49kfio)
Author: Tom Dowley
