### PR TITLE
Add Personal Roasts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@
 * There are 10 kinds of people in the world: those who understand binary and those who don't.
 * To err is human— to really foul things up you need a regex.
 * Welcome to programming: where the road to hell is paved with merge conflicts.
+
+---
+
+### 🧑‍💻 Personal Roast
+
+* You commit directly to main because “YOLO” is your version control strategy.
+* You think “clean code” means running Prettier and never looking back.
+* Your Stack Overflow searches have their own browser tab group.
+* You treat warnings like suggestions and errors like minor inconveniences.
+* Your idea of code review is checking if it compiles before merging.
+* You use TODO comments as a long-term storage solution.
+* You still debug with console.log, but call it “observability.”


### PR DESCRIPTION
This pull request modifies the README.md file to include a section of light-hearted roasts aimed at developers. The new section aims to bring humor to the documentation by poking fun at common developer habits and practices, such as committing directly to the main branch without caution and treating warnings as mere suggestions. These additions serve to create a more engaging and relatable README while highlighting some humorous aspects of programming culture.

---

> This pull request was co-created with Cosine Genie

Original Task: [sandbox/6dvk52fkwr4z](http://localhost:3000/tommy/sandbox/task/6dvk52fkwr4z)
Author: Tom Dowley
