### PR TITLE
Add humorous self-roasts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@
 * You use TODO comments as a long-term storage solution.
 * You still debug with console.log, but call it “observability.”
 * You asked an AI to roast you—because even your imposter syndrome needed a second opinion.
+* You write code like you’re paid by the bug.
+* Even your rubber duck is considering a career change.
+* Your “quick fixes” are the stuff of future postmortems.
+* Your codebase is the only place where Schrödinger’s bugs exist—both fixed and not fixed until someone checks.
+* You refactor so much, your codebase qualifies as performance art.


### PR DESCRIPTION
This pull request updates the README.md file by adding a series of light-hearted roasts aimed at the developer community. The new entries poke fun at common coding habits and experiences, such as: 

- Writing code like you're paid by the bug.
- Making rubber ducks reconsider their career choices.
- Transforming quick fixes into potential future postmortems.
- The nature of ‘Schrödinger's bugs’ in the codebase.

These additions not only bring humor to the documentation but also create a relatable atmosphere for developers who may be feeling the same struggles. Enjoy the roast!

---

> This pull request was co-created with Cosine Genie

Original Task: [sandbox/nq2gt0aanhnd](http://localhost:3000/tommy/sandbox/task/nq2gt0aanhnd)
Author: Tom Dowley
